### PR TITLE
On-demand PuNub library build

### DIFF
--- a/.github/workflows/build-c-static-library.yml
+++ b/.github/workflows/build-c-static-library.yml
@@ -1,4 +1,4 @@
-name: Build C-Core SDK static library
+name: Build static library
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
build(static-lib): on-demand PuNub library build

Add GitHub workflow to build and add new PubNub static library versions.