### PR TITLE
Fix clean up PubnubClients in tests.

### DIFF
--- a/.github/workflows/release/versions.json
+++ b/.github/workflows/release/versions.json
@@ -1,6 +1,6 @@
 {
   ".pubnub.yml": [
-    { "pattern": "^version: \"(.+)\"$", "cleared": true },
+    { "pattern": "^version: (.+)$", "cleared": true },
     { "pattern": "\/releases\/tag\/v([0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+)?)", "cleared": true }
   ],
   "PubnubLibrary.uplugin": [

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -3,6 +3,13 @@ schema: 1
 version: 2.0.0
 scm: github.com/pubnub/unreal-engine
 changelog:
+  - date: 2026-04-02
+    version: 2.0.1
+    changes:
+      - type: feature
+        text: "Add a way to change pn-sdk, so it can be used by UE Chat SDK."
+      - type: bug
+        text: "Fix cleaning up PubnubClient in tests, so they don't leave open connections."
   - date: 2026-03-31
     version: 2.0.0
     changes:

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,6 +1,6 @@
 name: unreal-engine
 schema: 1
-version: 2.0.0
+version: 2.0.1
 scm: github.com/pubnub/unreal-engine
 changelog:
   - date: 2026-04-02

--- a/PubnubLibrary.uplugin
+++ b/PubnubLibrary.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 16,
-	"VersionName": "2.0.0",
+	"VersionName": "2.0.1",
 	"FriendlyName": "Pubnub Unreal SDK",
 	"Description": "Quickly add interactive features to your game that scale without building your backend infrastructure.",
 	"Category": "Code",

--- a/PubnubLibrary.uplugin
+++ b/PubnubLibrary.uplugin
@@ -1,6 +1,6 @@
 {
 	"FileVersion": 3,
-	"Version": 15,
+	"Version": 16,
 	"VersionName": "2.0.0",
 	"FriendlyName": "Pubnub Unreal SDK",
 	"Description": "Quickly add interactive features to your game that scale without building your backend infrastructure.",

--- a/Source/PubnubLibrary/Private/PubnubClient.cpp
+++ b/Source/PubnubLibrary/Private/PubnubClient.cpp
@@ -2148,6 +2148,14 @@ TArray<UPubnubSubscriptionSet*> UPubnubClient::GetActiveSubscriptionSets()
 	return SubscriptionSets;
 }
 
+void UPubnubClient::SetRuntimeSdkVersionSuffix(FString Suffix)
+{
+	PUBNUB_RETURN_IF_CLIENT_NOT_INITIALIZED();
+	PUBNUB_LOG_FUNCTION_CALLED_TRACE();
+
+	SetRuntimeSdkVersionSuffix_priv(Suffix);
+}
+
 void UPubnubClient::InitWithConfig(UPubnubSubsystem* InPubnubSubsystem, FPubnubConfig InConfig, int InClientID, FString InDebugName )
 {
 	PubnubSubsystem = InPubnubSubsystem;
@@ -2286,6 +2294,9 @@ void UPubnubClient::DeinitializeClient()
 	delete[] OriginBuffer;
 	OriginBuffer = nullptr;
 	OriginLength = 0;
+	delete[] RuntimeSdkVersionSuffixBuffer;
+	RuntimeSdkVersionSuffixBuffer = nullptr;
+	RuntimeSdkVersionSuffixLength = 0;
 	delete PubnubCallsThread;
 	PubnubCallsThread = nullptr;
 
@@ -2588,6 +2599,8 @@ void UPubnubClient::InitPubnub_priv(const FPubnubConfig& Config)
 	pubnub_init(ctx_ee, PublishKey, SubscribeKey);
 	PUBNUB_LOG_FUNCTION_TRACE(TEXT("C-Core contexts initialized."));
 	AttachCCoreLogger();
+	
+	SetRuntimeSdkVersionSuffix_priv("-Pubnub-C-core/7.1.2/Unreal/2.0.1");
 
 	pubnub_subscribe_status_callback_t Callback = +[](const pubnub_t *pb, const pubnub_subscription_status status, const pubnub_subscription_status_data_t status_data, void* _data)
 	{
@@ -3497,6 +3510,33 @@ int UPubnubClient::SetOrigin_priv(FString Origin)
 	//This is just a setter, so no need to call it on a separate thread
 	Result = pubnub_origin_set(ctx_pub, OriginBuffer);
 	return Result;
+}
+
+void UPubnubClient::SetRuntimeSdkVersionSuffix_priv(FString Suffix)
+{
+	PUBNUB_LOG_FUNCTION_DEBUG_TEXT(FString::Printf(TEXT("set runtime sdk version suffix called. SuffixLength=%d"), Suffix.Len()));
+
+	delete[] RuntimeSdkVersionSuffixBuffer;
+	RuntimeSdkVersionSuffixBuffer = nullptr;
+	RuntimeSdkVersionSuffixLength = 0;
+
+	if (Suffix.IsEmpty())
+	{
+		pubnub_set_sdk_version_suffix(ctx_pub, nullptr);
+		pubnub_set_sdk_version_suffix(ctx_ee, nullptr);
+		PUBNUB_LOG_FUNCTION_TRACE(TEXT("runtime sdk version suffix reset to compile-time SDK identification."));
+		return;
+	}
+
+	FTCHARToUTF8 Converter(*Suffix);
+	RuntimeSdkVersionSuffixLength = Converter.Length();
+	RuntimeSdkVersionSuffixBuffer = new char[RuntimeSdkVersionSuffixLength + 1];
+	FMemory::Memcpy(RuntimeSdkVersionSuffixBuffer, Converter.Get(), RuntimeSdkVersionSuffixLength);
+	RuntimeSdkVersionSuffixBuffer[RuntimeSdkVersionSuffixLength] = '\0';
+
+	pubnub_set_sdk_version_suffix(ctx_pub, RuntimeSdkVersionSuffixBuffer);
+	pubnub_set_sdk_version_suffix(ctx_ee, RuntimeSdkVersionSuffixBuffer);
+	PUBNUB_LOG_FUNCTION_TRACE(TEXT("runtime sdk version suffix applied to pub and ee contexts."));
 }
 
 FPubnubFetchHistoryResult UPubnubClient::FetchHistory_priv(FString Channel, FPubnubFetchHistorySettings FetchHistorySettings)

--- a/Source/PubnubLibrary/Public/PubnubClient.h
+++ b/Source/PubnubLibrary/Public/PubnubClient.h
@@ -2586,6 +2586,12 @@ public:
 #pragma endregion 
 	
 
+	/**
+	 * Internal native API intended for integration layers such as PubnubChat. Don't use this function directly.
+	 */
+	void SetRuntimeSdkVersionSuffix(FString Suffix);
+
+
 private:
 
 	//Thread for all PubNub operations, this thread will queue all PubNub calls and trigger them one by one
@@ -2638,6 +2644,10 @@ private:
 	//Origin has to be kept alive for the lifetime of the sdk, so this is the container for it
 	char* OriginBuffer = nullptr;
 	size_t OriginLength = 0;
+
+	//Runtime SDK suffix has to be kept alive for the lifetime of the sdk, so this is the container for it
+	char* RuntimeSdkVersionSuffixBuffer = nullptr;
+	size_t RuntimeSdkVersionSuffixLength = 0;
 
 #pragma endregion 
 
@@ -2723,6 +2733,7 @@ private:
 	FString ParseToken_priv(FString Token);
 	void SetAuthToken_priv(FString Token);
 	int SetOrigin_priv(FString Origin);
+	void SetRuntimeSdkVersionSuffix_priv(FString Suffix);
 	FPubnubFetchHistoryResult FetchHistory_priv(FString Channel, FPubnubFetchHistorySettings FetchHistorySettings = FPubnubFetchHistorySettings());
 	FPubnubOperationResult DeleteMessages_priv(FString Channel, FPubnubDeleteMessagesSettings DeleteMessagesSettings);
 	FPubnubMessageCountsResult MessageCounts_priv(FString Channel, FString Timetoken);

--- a/Source/PubnubLibrary/Public/PubnubLibraryVersion.h
+++ b/Source/PubnubLibrary/Public/PubnubLibraryVersion.h
@@ -3,7 +3,7 @@
 #pragma once
 
 /** Keep in sync with VersionName in PubnubLibrary.uplugin. Used by dependent plugins (e.g. PubnubChat) for version checks. Two digits per component (max 99 each). */
-#define PUBNUB_LIBRARY_VERSION_MAJOR 1
-#define PUBNUB_LIBRARY_VERSION_MINOR 2
-#define PUBNUB_LIBRARY_VERSION_PATCH 0
+#define PUBNUB_LIBRARY_VERSION_MAJOR 2
+#define PUBNUB_LIBRARY_VERSION_MINOR 0
+#define PUBNUB_LIBRARY_VERSION_PATCH 1
 #define PUBNUB_LIBRARY_VERSION ((PUBNUB_LIBRARY_VERSION_MAJOR * 10000) + (PUBNUB_LIBRARY_VERSION_MINOR * 100) + PUBNUB_LIBRARY_VERSION_PATCH)

--- a/Source/PubnubLibraryTests/Private/Tests/PubnubTestsUtils.cpp
+++ b/Source/PubnubLibraryTests/Private/Tests/PubnubTestsUtils.cpp
@@ -3,6 +3,8 @@
 #if WITH_DEV_AUTOMATION_TESTS
 
 #include "Tests/PubnubTestsUtils.h"
+
+#include "PubnubClient.h"
 #include "Tests/AutomationCommon.h"
 #include "PubnubSubsystem.h"
 #include "Engine/GameInstance.h"
@@ -135,13 +137,21 @@ void FPubnubAutomationTestBase::CleanUp()
 	//Final clean up
 	ADD_LATENT_AUTOMATION_COMMAND(FDelayedFunctionLatentCommand([this]()
 	{
+		if (PubnubClient)
+		{
+			PubnubClient->DestroyClient();
+		}
+	}, 0.1f));
+	
+	ADD_LATENT_AUTOMATION_COMMAND(FDelayedFunctionLatentCommand([this]()
+	{
 		PubnubSubsystem->DeinitPubnub();
-	}, 0.2f));
+	}, 0.1f));
 
 	ADD_LATENT_AUTOMATION_COMMAND(FDelayedFunctionLatentCommand([this]()
 	{
 		GameInstance->Shutdown();
-	}, 0.2f));
+	}, 0.1f));
 	ADD_LATENT_AUTOMATION_COMMAND(FEngineWaitLatentCommand(0.2f));
 }
 


### PR DESCRIPTION
fix(test): Fix cleaning up PubnubClient in tests.

Fix cleaning up PubnubClient in tests, so they don't leave open connections.

feat(pnsdk): Add a way to change pn-sdk.

 Add a way to change pn-sdk, so it can be used by UE Chat SDK.