### PR TITLE
Make sure objects are not created during Garbage Collector work.

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,6 +1,6 @@
 name: unreal-engine
 schema: 1
-version: 2.0.3
+version: 2.0.4
 scm: github.com/pubnub/unreal-engine
 changelog:
   - date: 2026-04-23

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -3,6 +3,11 @@ schema: 1
 version: 2.0.4
 scm: github.com/pubnub/unreal-engine
 changelog:
+  - date: 2026-04-28
+    version: 2.0.4
+    changes:
+      - type: bug
+        text: "Fix very rare bug that objects could be created during Garbage Collector phase, what would end up in failing construction of the UObject."
   - date: 2026-04-23
     version: 2.0.3
     changes:

--- a/PubnubLibrary.uplugin
+++ b/PubnubLibrary.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 19,
-	"VersionName": "2.0.3",
+	"VersionName": "2.0.4",
 	"FriendlyName": "Pubnub Unreal SDK",
 	"Description": "Quickly add interactive features to your game that scale without building your backend infrastructure.",
 	"Category": "Code",

--- a/PubnubLibrary.uplugin
+++ b/PubnubLibrary.uplugin
@@ -1,6 +1,6 @@
 {
 	"FileVersion": 3,
-	"Version": 18,
+	"Version": 19,
 	"VersionName": "2.0.3",
 	"FriendlyName": "Pubnub Unreal SDK",
 	"Description": "Quickly add interactive features to your game that scale without building your backend infrastructure.",

--- a/Source/PubnubLibrary/Private/Entities/PubnubBaseEntity.cpp
+++ b/Source/PubnubLibrary/Private/Entities/PubnubBaseEntity.cpp
@@ -4,6 +4,7 @@
 #include "Entities/PubnubSubscription.h"
 #include "PubnubSubsystem.h"
 #include "PubnubClient.h"
+#include "FunctionLibraries/PubnubInternalUtilities.h"
 
 UPubnubSubscription* UPubnubBaseEntity::CreateSubscription(FPubnubSubscribeSettings SubscribeSettings)
 {
@@ -13,7 +14,7 @@ UPubnubSubscription* UPubnubBaseEntity::CreateSubscription(FPubnubSubscribeSetti
 		return nullptr;
 	}
 
-	UPubnubSubscription* Subscription = NewObject<UPubnubSubscription>(this);
+	UPubnubSubscription* Subscription = UPubnubInternalUtilities::SafeNewObject<UPubnubSubscription>(this);
 
 	Subscription->InitSubscription(PubnubClient, this, SubscribeSettings);
 

--- a/Source/PubnubLibrary/Private/Entities/PubnubSubscription.cpp
+++ b/Source/PubnubLibrary/Private/Entities/PubnubSubscription.cpp
@@ -140,7 +140,7 @@ UPubnubSubscriptionSet* UPubnubSubscription::AddSubscription(UPubnubSubscription
 		return nullptr;
 	}
 
-	UPubnubSubscriptionSet* SubscriptionSet = NewObject<UPubnubSubscriptionSet>(this);
+	UPubnubSubscriptionSet* SubscriptionSet = UPubnubInternalUtilities::SafeNewObject<UPubnubSubscriptionSet>(this);
 	SubscriptionSet->InitWithSubscriptions(PubnubClient, this, Subscription);
 	
 	return SubscriptionSet;

--- a/Source/PubnubLibrary/Private/PubnubClient.cpp
+++ b/Source/PubnubLibrary/Private/PubnubClient.cpp
@@ -1914,7 +1914,7 @@ void UPubnubClient::SetCryptoModule(TScriptInterface<IPubnubCryptoProviderInterf
 	}
 	else
 	{
-		CryptoBridge = NewObject<UPubnubCryptoBridge>(this);
+		CryptoBridge = UPubnubInternalUtilities::SafeNewObject<UPubnubCryptoBridge>(this);
 		CryptoBridge->InitCryptoBridge(CryptoModule);
 
 		pubnub_set_crypto_module(ctx_pub, CryptoBridge->GetProvider());
@@ -2006,7 +2006,7 @@ UPubnubChannelEntity* UPubnubClient::CreateChannelEntity(FString Channel)
 	PUBNUB_LOG_FUNCTION_CALLED_TRACE();
 	PUBNUB_RETURN_IF_FIELD_EMPTY(Channel, nullptr);
 	
-	UPubnubChannelEntity* ChannelEntity = NewObject<UPubnubChannelEntity>(this);
+	UPubnubChannelEntity* ChannelEntity = UPubnubInternalUtilities::SafeNewObject<UPubnubChannelEntity>(this);
 	ChannelEntity->InitEntity(this);
 	ChannelEntity->EntityID = Channel;
 	PUBNUB_LOG_FUNCTION_DEBUG_TEXT(FString::Printf(TEXT("channel entity created for '%s'."), *Channel));
@@ -2018,7 +2018,7 @@ UPubnubChannelGroupEntity* UPubnubClient::CreateChannelGroupEntity(FString Chann
 	PUBNUB_LOG_FUNCTION_CALLED_TRACE();
 	PUBNUB_RETURN_IF_FIELD_EMPTY(ChannelGroup, nullptr);
 	
-	UPubnubChannelGroupEntity* ChannelGroupEntity = NewObject<UPubnubChannelGroupEntity>(this);
+	UPubnubChannelGroupEntity* ChannelGroupEntity = UPubnubInternalUtilities::SafeNewObject<UPubnubChannelGroupEntity>(this);
 	ChannelGroupEntity->InitEntity(this);
 	ChannelGroupEntity->EntityID = ChannelGroup;
 	PUBNUB_LOG_FUNCTION_DEBUG_TEXT(FString::Printf(TEXT("channel group entity created for '%s'."), *ChannelGroup));
@@ -2030,7 +2030,7 @@ UPubnubChannelMetadataEntity* UPubnubClient::CreateChannelMetadataEntity(FString
 	PUBNUB_LOG_FUNCTION_CALLED_TRACE();
 	PUBNUB_RETURN_IF_FIELD_EMPTY(Channel, nullptr);
 	
-	UPubnubChannelMetadataEntity* ChannelMetadataEntity = NewObject<UPubnubChannelMetadataEntity>(this);
+	UPubnubChannelMetadataEntity* ChannelMetadataEntity = UPubnubInternalUtilities::SafeNewObject<UPubnubChannelMetadataEntity>(this);
 	ChannelMetadataEntity->InitEntity(this);
 	ChannelMetadataEntity->EntityID = Channel;
 	PUBNUB_LOG_FUNCTION_DEBUG_TEXT(FString::Printf(TEXT("channel metadata entity created for '%s'."), *Channel));
@@ -2042,7 +2042,7 @@ UPubnubUserMetadataEntity* UPubnubClient::CreateUserMetadataEntity(FString User)
 	PUBNUB_LOG_FUNCTION_CALLED_TRACE();
 	PUBNUB_RETURN_IF_FIELD_EMPTY(User, nullptr);
 	
-	UPubnubUserMetadataEntity* UserMetadataEntity = NewObject<UPubnubUserMetadataEntity>(this);
+	UPubnubUserMetadataEntity* UserMetadataEntity = UPubnubInternalUtilities::SafeNewObject<UPubnubUserMetadataEntity>(this);
 	UserMetadataEntity->InitEntity(this);
 	UserMetadataEntity->EntityID = User;
 	PUBNUB_LOG_FUNCTION_DEBUG_TEXT(FString::Printf(TEXT("user metadata entity created for '%s'."), *User));
@@ -2057,7 +2057,7 @@ UPubnubSubscriptionSet* UPubnubClient::CreateSubscriptionSet(TArray<FString> Cha
 	{
 		PUBNUB_LOG_FUNCTION_WARNING(TEXT("[CreateSubscriptionSet]: at least one Channel or ChannelGroup is needed to create SubscriptionSet."));
 	}
-	UPubnubSubscriptionSet* SubscriptionSet = NewObject<UPubnubSubscriptionSet>(this);
+	UPubnubSubscriptionSet* SubscriptionSet = UPubnubInternalUtilities::SafeNewObject<UPubnubSubscriptionSet>(this);
 	SubscriptionSet->InitSubscriptionSet(this, Channels, ChannelGroups, SubscriptionSettings);
 	PUBNUB_LOG_FUNCTION_DEBUG_TEXT(TEXT("subscription set created."));
 	return SubscriptionSet;
@@ -2079,7 +2079,7 @@ UPubnubSubscriptionSet* UPubnubClient::CreateSubscriptionSetFromEntities(TArray<
 		Entity->EntityType == EPubnubEntityType::PEnT_ChannelGroup? ChannelGroups.Add(Entity->EntityID) : Channels.Add(Entity->EntityID);
 	}
 	
-	UPubnubSubscriptionSet* SubscriptionSet = NewObject<UPubnubSubscriptionSet>(this);
+	UPubnubSubscriptionSet* SubscriptionSet = UPubnubInternalUtilities::SafeNewObject<UPubnubSubscriptionSet>(this);
 	SubscriptionSet->InitSubscriptionSet(this, Channels, ChannelGroups, SubscriptionSettings);
 	PUBNUB_LOG_FUNCTION_DEBUG_TEXT(FString::Printf(TEXT("subscription set created from entities. ChannelsCount=%d, ChannelGroupsCount=%d"), Channels.Num(), ChannelGroups.Num()));
 	return SubscriptionSet;
@@ -2100,7 +2100,7 @@ TArray<UPubnubSubscription*> UPubnubClient::GetActiveSubscriptions()
 
 	for(pubnub_subscription_t* CCoreSub : MakeArrayView(CCoreSubs, Count))
 	{
-		UPubnubSubscription* Subscription = NewObject<UPubnubSubscription>(this);
+		UPubnubSubscription* Subscription = UPubnubInternalUtilities::SafeNewObject<UPubnubSubscription>(this);
 		Subscription->InitWithCCoreSubscription(this, CCoreSub);
 		Subscriptions.Add(Subscription);
 	}
@@ -2123,7 +2123,7 @@ TArray<UPubnubSubscriptionSet*> UPubnubClient::GetActiveSubscriptionSets()
 
 	for(pubnub_subscription_set_t* CCoreSubsSet : MakeArrayView(CCoreSubSets, Count))
 	{
-		UPubnubSubscriptionSet* SubscriptionSet = NewObject<UPubnubSubscriptionSet>(this);
+		UPubnubSubscriptionSet* SubscriptionSet = UPubnubInternalUtilities::SafeNewObject<UPubnubSubscriptionSet>(this);
 		SubscriptionSet->InitWithCCoreSubscriptionSet(this, CCoreSubsSet);
 		SubscriptionSets.Add(SubscriptionSet);
 		
@@ -2139,7 +2139,7 @@ TArray<UPubnubSubscriptionSet*> UPubnubClient::GetActiveSubscriptionSets()
 
 		for(pubnub_subscription_t* CCoreSub : MakeArrayView(CCoreSubs, Count))
 		{
-			UPubnubSubscription* Subscription = NewObject<UPubnubSubscription>(this);
+			UPubnubSubscription* Subscription = UPubnubInternalUtilities::SafeNewObject<UPubnubSubscription>(this);
 			Subscription->InitWithCCoreSubscription(this, CCoreSub);
 			SubscriptionSet->Subscriptions.Add(Subscription);
 		}
@@ -2162,7 +2162,7 @@ void UPubnubClient::InitWithConfig(UPubnubSubsystem* InPubnubSubsystem, FPubnubC
 	ClientID = InClientID;
 	DebugName = InDebugName;
 
-	LoggerManager = NewObject<UPubnubLogManager>(this);
+	LoggerManager = UPubnubInternalUtilities::SafeNewObject<UPubnubLogManager>(this);
 	if (LoggerManager)
 	{
 		const FString EmitterID = DebugName.IsEmpty()
@@ -2172,7 +2172,7 @@ void UPubnubClient::InitWithConfig(UPubnubSubsystem* InPubnubSubsystem, FPubnubC
 
 		if (InConfig.LoggerConfig.bEnableDefaultLogger)
 		{
-			DefaultLogger = NewObject<UPubnubDefaultLogger>(this);
+			DefaultLogger = UPubnubInternalUtilities::SafeNewObject<UPubnubDefaultLogger>(this);
 			if (DefaultLogger)
 			{
 				IPubnubLoggerInterface::Execute_SetMinimumLogLevel(DefaultLogger, InConfig.LoggerConfig.DefaultLoggerMinLevel);
@@ -2469,9 +2469,18 @@ void UPubnubClient::OnCCoreSubscriptionStatusReceived(int StatusEnum, const void
 	}
 	PUBNUB_LOG_FUNCTION_TRACE(FString::Printf(TEXT("subscription status payload parsed. ChannelsCount=%d, ChannelGroupsCount=%d"), SubscriptionStatusData.Channels.Num(), SubscriptionStatusData.ChannelGroups.Num()));
 
-	//Call SubscriptionStatusChanged delegates 
-	OnSubscriptionStatusChanged.Broadcast((EPubnubSubscriptionStatus)status, SubscriptionStatusData);
-	OnSubscriptionStatusChangedNative.Broadcast((EPubnubSubscriptionStatus)status, SubscriptionStatusData);
+	//Dispatch SubscriptionStatusChanged delegates on the game thread.
+
+	TWeakObjectPtr<UPubnubClient> ThisClientWeak = MakeWeakObjectPtr<UPubnubClient>(this);
+	const EPubnubSubscriptionStatus FinalStatus = (EPubnubSubscriptionStatus)status;
+	AsyncTask(ENamedThreads::GameThread, [ThisClientWeak, FinalStatus, SubscriptionStatusData]()
+	{
+		if(ThisClientWeak.IsValid())
+		{
+			ThisClientWeak.Get()->OnSubscriptionStatusChanged.Broadcast(FinalStatus, SubscriptionStatusData);
+			ThisClientWeak.Get()->OnSubscriptionStatusChangedNative.Broadcast(FinalStatus, SubscriptionStatusData);
+		}
+	});
 }
 
 FString UPubnubClient::GetLastResponse(pubnub_t* context)

--- a/Source/PubnubLibrary/Private/PubnubSubsystem.cpp
+++ b/Source/PubnubLibrary/Private/PubnubSubsystem.cpp
@@ -6,6 +6,7 @@
 #include "PubnubInternalMacros.h"
 #include "FunctionLibraries/PubnubJsonUtilities.h"
 #include "FunctionLibraries/PubnubUtilities.h"
+#include "FunctionLibraries/PubnubInternalUtilities.h"
 #include "PubnubClient.h"
 
 DEFINE_LOG_CATEGORY(PubnubLog)
@@ -31,7 +32,7 @@ void UPubnubSubsystem::Deinitialize()
 
 UPubnubClient* UPubnubSubsystem::CreatePubnubClient(FPubnubConfig Config, FString DebugName)
 {
-	UPubnubClient* PubnubClient = NewObject<UPubnubClient>(this);
+	UPubnubClient* PubnubClient = UPubnubInternalUtilities::SafeNewObject<UPubnubClient>(this);
 
 	int NewID = NextClientID++;
 

--- a/Source/PubnubLibrary/Public/FunctionLibraries/PubnubInternalUtilities.h
+++ b/Source/PubnubLibrary/Public/FunctionLibraries/PubnubInternalUtilities.h
@@ -5,6 +5,7 @@
 #include "CoreMinimal.h"
 #include "PubNub.h"
 #include "Kismet/BlueprintFunctionLibrary.h"
+#include "UObject/GarbageCollection.h"
 #include "PubnubStructLibrary.h"
 #include "PubnubInternalUtilities.generated.h"
 
@@ -48,4 +49,21 @@ public:
 	static void EEAddSubscriptionSetListenersOfAllTypes(pubnub_subscription_set_t* SubscriptionSet, pubnub_subscribe_message_callback_t Callback, void* UserData);
 	static bool EERemoveSubscriptionSetListenerOfType(pubnub_subscription_set_t** SubscriptionSetPtr, pubnub_subscribe_message_callback_t Callback, EPubnubListenerType ListenerType, void* UserData);
 	static void EERemoveSubscriptionSetListenersOfAllTypes(pubnub_subscription_set_t** SubscriptionSetPtr, pubnub_subscribe_message_callback_t Callback, void* UserData);
+
+
+	/* TEMPLATES */
+
+	/**
+	 * Thread-safe wrapper around NewObject<T>.
+	 *
+	 * FGCScopeGuard takes Unreal's GC async lock, which prevents GC from starting while the
+	 * guard is alive (and waits for an in-progress GC to finish before returning from its
+	 * constructor). Holding it across the NewObject call.
+	 */
+	template<typename ObjectType, typename OuterType>
+	static ObjectType* SafeNewObject(OuterType* Outer)
+	{
+		FGCScopeGuard GCGuard;
+		return NewObject<ObjectType>(Outer);
+	}
 };

--- a/Source/PubnubLibrary/Public/PubnubLibraryVersion.h
+++ b/Source/PubnubLibrary/Public/PubnubLibraryVersion.h
@@ -8,5 +8,5 @@
 /** Keep in sync with VersionName in PubnubLibrary.uplugin. Used by dependent plugins (e.g. PubnubChat) for version checks. Two digits per component (max 99 each). */
 #define PUBNUB_LIBRARY_VERSION_MAJOR 2
 #define PUBNUB_LIBRARY_VERSION_MINOR 0
-#define PUBNUB_LIBRARY_VERSION_PATCH 3
+#define PUBNUB_LIBRARY_VERSION_PATCH 4
 #define PUBNUB_LIBRARY_VERSION ((PUBNUB_LIBRARY_VERSION_MAJOR * 10000) + (PUBNUB_LIBRARY_VERSION_MINOR * 100) + PUBNUB_LIBRARY_VERSION_PATCH)


### PR DESCRIPTION
fix: Make sure objects are not created during Garbage Collector work.

Fix very rare bug that objects could be created during Garbage Collector phase, what would end up in failing construction of the UObject.